### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/katministratie/a44dd187-7e47-4eb9-89f6-00d06dc653d8/2dcdea51-ac7a-4d8e-a114-071f29c7cf81/_apis/work/boardbadge/f6d45914-ce28-4b57-9332-3da18235a5f6)](https://dev.azure.com/katministratie/a44dd187-7e47-4eb9-89f6-00d06dc653d8/_boards/board/t/2dcdea51-ac7a-4d8e-a114-071f29c7cf81/Microsoft.RequirementCategory)
 Project om de administratie van katten door de vrijwilligers en gastgezinnen makkelijker te laten verlopen.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/katministratie/a44dd187-7e47-4eb9-89f6-00d06dc653d8/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.